### PR TITLE
Add required date element to CapabilityStatement

### DIFF
--- a/resources/CapabilityStatement-dwv-SendReceive.xml
+++ b/resources/CapabilityStatement-dwv-SendReceive.xml
@@ -8,6 +8,7 @@
     <name value="DwvSendReceive"/>
     <title value="dwv SendReceive"/>
     <status value="active"/>
+    <date value="2022-08-30"/>
     <publisher value="Nictiz"/>
     <contact>
         <name value="Nictiz"/>

--- a/resources/dwv-PatientCorrectionsCommunication.xml
+++ b/resources/dwv-PatientCorrectionsCommunication.xml
@@ -41,7 +41,7 @@
   </mapping>
   <mapping>
     <identity value="art-decor-dossierwijzigingsverzoek" />
-    <uri value="https://decor.nictiz.nl/art-decor/decor-datasets--dwv-?id=2.16.840.1.113883.2.4.3.11.60.130.1.1&amp;effectiveDate=2021-11-17T16%3A56%3A44" />
+    <uri value="https://decor.nictiz.nl/pub/dossierwijzigingsverzoek/dwv-html-20220826T185150/ds-2.16.840.1.113883.2.4.3.11.60.130.1.1-2021-11-17T165644.html" />
     <name value="ART-DECOR-dataset Dossierwijzigingsverzoek" />
   </mapping>
   <kind value="resource" />


### PR DESCRIPTION
Created an RC1 package, would not upload to Touchstone.

Found that the CapabilityStatement missed a 1..1 `date` element, so added that.

Created an RC2 package, still does not want to upload to Touchstone. TBC - https://bits.nictiz.nl/browse/KT-309